### PR TITLE
[0.5.1] - 2023-11-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.5.1] - 2023-11-26
+### Changed
+- pyproject.toml: Rolling back Python version to 3.11.  v3.12 not in widespread
+  use yet...
+
+
 ## [0.5.0] - 2023-11-24
 ### Fixed
 - grafana/grafana_dashboard.json: Updated dashboard JSON which should fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "speedtest_aio"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Python script to capture speedtest JSON and insert it into a database."
 authors = ["Aaron Melton <aaron@aaronmelton.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 aaron-common-libs = {git = "https://github.com/aaronmelton/aaron-common-libs.git"}
 speedtest-cli = "^2.1.3"
 

--- a/speedtest_aio/config.py
+++ b/speedtest_aio/config.py
@@ -16,11 +16,11 @@ class Config:  # pylint: disable=too-many-instance-attributes
         """Application Variables."""
         self.app_dict = {
             "author": "Aaron Melton <aaron@aaronmelton.com>",
-            "date": "2023-11-19",
+            "date": "2023-11-26",
             "desc": "A Python script to capture speedtest JSON and insert it into a database.",
             "title": "speedtest_aio",
             "url": "https://github.com/aaronmelton/speedtest_aio",
-            "version": "0.5.0",
+            "version": "0.5.1",
         }
 
         # Logging Variables


### PR DESCRIPTION
## [0.5.1] - 2023-11-26
### Changed
- pyproject.toml: Rolling back Python version to 3.11.  v3.12 not in widespread
use yet...
